### PR TITLE
:bug: Fixes bug 28 which caused the wrong env to be used in the

### DIFF
--- a/LAC_TF115_CLEANED_SEEDED_SAC_INCL/lac.py
+++ b/LAC_TF115_CLEANED_SEEDED_SAC_INCL/lac.py
@@ -803,6 +803,7 @@ def train(log_dir):
     # Create environment
     print(f"Your training in the {ENV_NAME} environment.\n")
     env = get_env_from_name(ENV_NAME, ENV_SEED)
+    test_env = get_env_from_name(ENV_NAME, ENV_SEED)
 
     # Set initial learning rates
     lr_a, lr_l, lr_c = (
@@ -1025,7 +1026,7 @@ def train(log_dir):
                 training_diagnostics = evaluate_training_rollouts(last_training_paths)
                 if training_diagnostics is not None:
                     if TRAIN_PARAMS["num_of_evaluation_paths"] > 0:
-                        eval_diagnostics = training_evaluation(env, policy)
+                        eval_diagnostics = training_evaluation(test_env, policy)
                         [
                             logger.logkv(key, eval_diagnostics[key])
                             for key in eval_diagnostics.keys()

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ conda create -n lac_old python=3.6
 
 To activate the env:
 
-    conda activate lac_old
+```bash
+conda activate lac_old
+```
 
 ### Installation Environment
 


### PR DESCRIPTION
evaluation

Fixes #28 which caused the main environment to be used in the test
policy evluation during training. This does not work with all
environment. A new test environment was therefore created ad passed to
the training_evaluation function.